### PR TITLE
Validate and harden /admin/update_targets JSON handling

### DIFF
--- a/server.py
+++ b/server.py
@@ -83,9 +83,12 @@ def reject_agent(agent_db_id):
 @app.route('/admin/update_targets', methods=['POST'])
 def update_targets():
     global current_targets
-    new_targets = request.json.get('targets')
-    if new_targets is None:
+    payload = request.get_json(silent=True)
+    if payload is None or 'targets' not in payload:
         return jsonify({'error': 'No targets provided'}), 400
+    new_targets = payload.get('targets')
+    if not isinstance(new_targets, list) or not all(isinstance(target, str) for target in new_targets):
+        return jsonify({'error': 'Targets must be a list of strings'}), 400
     current_targets = new_targets
     socketio.emit('server_message', {'type': 'update_targets', 'targets': current_targets},
                   namespace='/agent')


### PR DESCRIPTION
### Motivation
- The endpoint previously accessed `request.json.get('targets')` directly which can fail or behave unpredictably when the request body is missing or not valid JSON.
- Ensure the API returns clear `400` errors for missing or malformed payloads instead of causing server-side errors.
- Prevent assigning invalid types to `current_targets` by enforcing a list-of-strings contract.

### Description
- Replace direct use of `request.json.get('targets')` with `request.get_json(silent=True)` and guard against a `None` payload or missing `targets` key.
- Return `400` with `{'error': 'No targets provided'}` when the payload is absent or lacks `targets`.
- Validate that `targets` is a list where every element is a string and return `400` with `{'error': 'Targets must be a list of strings'}` on validation failure.
- Preserve the existing success path by assigning `current_targets`, emitting the `server_message` via `socketio.emit`, and returning the updated JSON response.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962ff8602ec83308a98972a31bd6d4f)