### PR TITLE
Document `getLocalIP()` usage for handshake IP in agent implementation docs

### DIFF
--- a/agent-implementation.md
+++ b/agent-implementation.md
@@ -39,7 +39,7 @@ func main() {
     defer ws.Close()
 
     hostname, _ := os.Hostname()
-    ipAddress := "取得したローカルIP" // IP アドレスの取得ロジックを実装する必要あり
+    ipAddress := getLocalIP() // agent.go では getLocalIP() を利用（UDPで8.8.8.8:80へ接続しLocalAddr()からIP取得）
     handshake := HandshakeMessage{
         Passphrase: passphrase,
         Hostname:   hostname,


### PR DESCRIPTION
### Motivation
- Ensure the handshake example in the documentation reflects the actual behavior implemented in `agent.go` for obtaining the local IP.
- Remove a vague placeholder and replace it with a concrete reference to the real helper used by the agent.
- Provide a brief explanation so readers understand how the IP is derived without inspecting `agent.go`.

### Description
- Updated `agent-implementation.md` to replace `ipAddress := "取得したローカルIP"` with `ipAddress := getLocalIP()` and an inline note.
- The inline note states that `getLocalIP()` dials UDP to `8.8.8.8:80` and uses `LocalAddr()` to derive the local IP address.
- Kept the surrounding handshake explanation consistent with the existing behavior in `agent.go`.

### Testing
- This is a documentation-only change so no unit or integration tests were run.
- No automated tests were executed and no runtime behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962ff879058833097f5f3e1fafe8445)