### PR TITLE
Add English implementation status report

### DIFF
--- a/implementation-status-en.md
+++ b/implementation-status-en.md
@@ -1,0 +1,64 @@
+# Implementation Status Report (PoC Gap Summary)
+
+## 1. Core PoC behaviors implemented (server.py / agent.go)
+
+### Agent handshake & registration
+- server.py: On the `/agent` namespace, the `handshake` event receives passphrase/hostname/ip_address/version, creates a pending record for new agents, and places approved agents into hold if the IP changes. It replies with the registration state.
+- agent.go: Sends the handshake on startup and exits if the returned status is pending/hold.
+
+### Approval flow
+- server.py: Approving sets status=approved and assigns agent_id, then pushes the current targets to agents.
+- server.py: Rejection sets status=blacklisted.
+
+### Target list distribution (push)
+- server.py: Admin API/form updates current_targets and pushes update_targets to all agents.
+- agent.go: Receives update_targets, updates targets, and unblocks initial wait on first update.
+
+### ICMP monitoring & reporting
+- agent.go: Every 5 seconds, sends ICMP echo to all targets concurrently and records RTT in ms on success.
+- agent.go: Sends results as MonitoringDataMessage over WebSocket.
+
+### Data storage
+- server.py: Persists monitoring_data to SQLite.
+
+### 1-hour cache
+- server.py: Keeps the last hour in recent_cache and serves it via /monitoring/<agent>/<target>.
+
+## 2. Gaps vs specs.txt (unimplemented / partial)
+
+### Unimplemented
+- User management (registration/roles/login/password reset)
+- Real-time monitoring UI (grid view with color status)
+- Passphrase generation & encrypted exchange (including registration screen)
+- 24-hour data retention (DB retention/cleanup policy)
+- Agent-side 30-minute buffer with TTL
+
+### Partial
+- Hover visualization: 1-hour data API exists, UI is missing/unverified
+- TLS: server.py sets an SSL context, but agent.go uses ws://
+
+## 3. Baseline expectations vs. reality (for future issues)
+
+- Expectation: TLS WebSocket communication → Reality: server SSL exists, agent uses ws://
+- Expectation: real-time monitoring UI/hover UI → Reality: API exists in part, UI not implemented
+- Expectation: 24-hour data retention → Reality: only 1-hour cache is implemented; DB retention is missing
+
+## 4. Living checklist (gap tracking)
+
+### Server
+- [x] Handshake / provisional registration / hold handling
+- [x] Admin approve / reject
+- [x] Target list push
+- [x] Monitoring data storage + 1-hour cache
+- [ ] User management
+- [ ] Real-time monitoring UI
+- [ ] Hover UI
+- [ ] Passphrase encryption / registration screen
+- [ ] 24-hour retention
+- [ ] TLS (agent wss support)
+
+### Agent
+- [x] ICMP monitoring (5s interval, concurrent)
+- [x] Target update reception
+- [x] Send-failure buffer
+- [ ] 30-minute buffer (TTL)

--- a/implementation-status.md
+++ b/implementation-status.md
@@ -1,0 +1,64 @@
+# 実装状況レポート（PoCギャップ整理）
+
+## 1. PoCで実装済みのコア挙動（server.py / agent.go）
+
+### エージェントハンドシェイク・登録
+- server.py: `/agent` namespace の `handshake` イベントで passphrase/hostname/ip_address/version を受け取り、未登録なら pending で仮登録。既存エージェントで IP が変わった場合は hold へ変更し、登録状態を返信する。
+- agent.go: 起動時に handshake を送信し、返却された registration_status が pending/hold の場合は終了。
+
+### 承認フロー
+- server.py: 管理画面から承認時に status=approved とし agent_id を付与。承認済みエージェントへ監視対象リストを push。
+- server.py: 拒否時は status=blacklisted に更新。
+
+### 監視対象リストの配信（ターゲットプッシュ）
+- server.py: 管理API・管理フォームから current_targets を更新し、全エージェントへ update_targets を push。
+- agent.go: update_targets を受信して targets を更新し、初回更新で待機解除。
+
+### ICMP監視と送信
+- agent.go: 5秒ごとに全ターゲットへ ICMP Echo を送信（並行処理）。成功時の RTT をミリ秒で記録。
+- agent.go: 監視結果を MonitoringDataMessage として WebSocket 経由で送信。
+
+### データ保存
+- server.py: monitoring_data を受信したら SQLite に保存。
+
+### 1時間キャッシュ
+- server.py: recent_cache に直近1時間分の MonitoringData を保持し、/monitoring/<agent>/<target> で返却。
+
+## 2. specs.txt との未実装・部分実装チェック
+
+### 未実装
+- ユーザ管理（登録/権限/ログイン/パスワードリセット）
+- リアルタイム監視画面（行×列の秒単位UI、色分け）
+- パスフレーズ生成・暗号化交換（新規登録画面含む）
+- 24時間のデータリテンション（DB保持/削除ポリシー）
+- エージェント側の30分バッファ（TTL管理）
+
+### 部分実装
+- ホバー表示: 1時間分データ取得 API は存在するが、UI 実装は未確認/未実装
+- TLS: server.py は SSL context を指定するが、agent.go は ws:// を使用
+
+## 3. Baseline expectations vs. reality（将来 issue 用メモ）
+
+- 期待: TLSでのWebSocket通信 → 実態: サーバはSSL設定あり、エージェントは ws://
+- 期待: リアルタイム監視UI/ホバーUI → 実態: APIは一部あり、UIは未実装
+- 期待: 24時間データ保持 → 実態: 1時間キャッシュのみ実装、DB保持は未実装
+
+## 4. ギャップ追跡のチェックリスト（Living）
+
+### Server
+- [x] ハンドシェイク/仮登録/保留処理
+- [x] 管理承認/拒否
+- [x] 監視対象リスト push
+- [x] 監視データ保存 + 1時間キャッシュ
+- [ ] ユーザ管理
+- [ ] リアルタイム監視UI
+- [ ] ホバーUI
+- [ ] パスフレーズ暗号化/登録画面
+- [ ] 24時間リテンション
+- [ ] TLS (agent側 wss 対応)
+
+### Agent
+- [x] ICMP監視（5秒間隔・並行）
+- [x] 監視対象の更新受信
+- [x] 送信失敗バッファ
+- [ ] 30分バッファ（TTL管理）


### PR DESCRIPTION
### Motivation
- Provide an English version of the implementation status report to accompany the existing Japanese `implementation-status.md`.
- Surface implemented PoC behaviors and highlight gaps relative to `specs.txt` for cross-team visibility.
- Create a living checklist to track follow-up work and prioritize issues across Server and Agent.

### Description
- Add `implementation-status-en.md` that mirrors the Japanese report and summarizes PoC behaviors, gaps, baseline-vs-reality notes, and a living checklist.
- Document core implemented behaviors including agent handshake/registration, approval flow, target list push, ICMP monitoring, data persistence, and a 1-hour recent cache.
- Enumerate unimplemented or partially implemented items such as user management, real-time UI, passphrase encryption, 24-hour retention, TLS mismatch, and agent buffer TTL.
- Include a Server/Agent checklist to track completed and outstanding items for future work.

### Testing
- No automated tests were run because this is a documentation-only change.
- The file `implementation-status-en.md` was added to the repository and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963108ee43483309131761e45845fbc)